### PR TITLE
Alter Makefiles to get arm64 alpine building

### DIFF
--- a/Dockerfile.alpine.arm64
+++ b/Dockerfile.alpine.arm64
@@ -13,10 +13,14 @@ RUN cd httpd-2.2.34 \
 # Build PHP 4
 ADD php-4.4.9.tar.bz2 .
 ADD php.ini /usr/local/apache2/php.ini
-RUN cd php-4.4.9 \
-  && ./configure --with-apxs2=/usr/local/apache2/bin/apxs --with-mysql --enable-force-cgi-redirect --disable-cgi --with-zlib --with-imap \
-  --with-config-file-path=/usr/local/apache2 --host=aarch64-unknown-linux-gnu \
-  && make && make install
+
+WORKDIR /tmp/php-4.4.9
+RUN ./configure --with-apxs2=/usr/local/apache2/bin/apxs --with-mysql --enable-force-cgi-redirect --disable-cgi --with-zlib --with-imap --with-config-file-path=/usr/local/apache2 --host=aarch64-unknown-linux-gnu
+RUN sed -i "/CFLAGS_CLEAN =/c\CFLAGS_CLEAN = -g -O2 -fcommon" Makefile
+RUN sed -i "/CPP =/c\CPP = gcc -E -fcommon" Makefile
+RUN make && make install
+
+WORKDIR /tmp
 
 # Setup PHP to Run on Apache
 RUN echo 'AddType application/x-httpd-php php' >> /usr/local/apache2/conf/httpd.conf \
@@ -24,10 +28,15 @@ RUN echo 'AddType application/x-httpd-php php' >> /usr/local/apache2/conf/httpd.
 
 # Build Mysql 4
 ADD mysql-4.1.22.tar.bz2 .
-RUN echo '/* Linuxthreads */' >> /usr/include/pthread.h \ 
-  && cd mysql-4.1.22 \
-  && ./configure --prefix=/usr/local/mysql --build=aarch64-unknown-linux-gnu CXXFLAGS="-std=gnu++98" \
-  && make && make install
+
+RUN echo '/* Linuxthreads */' >> /usr/include/pthread.h
+WORKDIR /tmp/mysql-4.1.22
+RUN ./configure --prefix=/usr/local/mysql --build=aarch64-unknown-linux-gnu CXXFLAGS="-std=gnu++98 -fpermissive"
+RUN sed -i "/HAVE_GETHOSTBYADDR_R/d" config.h
+RUN sed -i "/HAVE_GETHOSTBYNAME_R/d" config.h
+RUN make && make install
+
+WORKDIR /tmp
 
 # Linuxtrheads hack explained: https://bugs.mysql.com/bug.php?id=19785
 # gnu++98 (error: narrowing conversion):  https://bugs.mysql.com/bug.php?id=19785

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ This Dockerfile builds this old stack trying to keep everything as it used to be
 
     docker run -d --name php4 --restart=always -p 80:80 -v `pwd`/data:/usr/local/mysql/var -v `pwd`/app:/usr/local/apache2/htdocs php4
 
+## Or with docker compose (alpine.arm64)
+
+    docker compose up -d
+
 ### Data Volume (mysql/var)
 
 Must be the copy of the database folder of your old mysql application. All the users, tables, root password, etc. will be the same.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  php4:
+    build:
+      context: .
+      dockerfile: Dockerfile.alpine.arm64
+    restart: always
+    ports:
+      - 80:80
+    volumes:
+      - ./data:/usr/local/mysql/var
+      - ./app:/usr/local/apache2/htdocs


### PR DESCRIPTION
I'm sure there's a better way, but this managed to work. macOS/Docker Desktop 4.30.0/Docker 26.1.1